### PR TITLE
Package setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.8)
+project(aaveq_dynamics)
+
+add_compile_options(-Wall -Wextra -Wpedantic)
+set(CMAKE_CXX_STANDARD 20)
+
+
+############################################################################
+
+# Dependencies
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(Eigen3 REQUIRED)
+
+############################################################################
+
+# Libraries
+
+include_directories(include)
+
+install(
+  DIRECTORY include/aaveq_dynamics
+  DESTINATION include)
+
+############################################################################
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,20 @@ install(
   DIRECTORY include/aaveq_dynamics
   DESTINATION include)
 
+## Master include
+add_library(adynamics INTERFACE)
+ament_export_targets(export_adynamics HAS_LIBRARY_TARGET)
+
+install(
+    TARGETS adynamics
+    EXPORT export_adynamics
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+)
+ament_export_include_directories(include)
+
 ## utils
 add_library(utils src/utils.cpp)
 target_link_libraries(utils Eigen3::Eigen jsoncpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,19 @@ install(
   DIRECTORY include/aaveq_dynamics
   DESTINATION include)
 
+## utils
+add_library(utils src/utils.cpp)
+target_link_libraries(utils Eigen3::Eigen jsoncpp)
+ament_export_targets(utils HAS_LIBRARY_TARGET)
+
+install(
+  TARGETS utils
+  EXPORT utils
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include)
+
 ############################################################################
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,19 @@ install(
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include)
 
+## rigid_body_dynamics
+add_library(rigid_body_dynamics src/rigid_body_dynamics.cpp)
+target_link_libraries(rigid_body_dynamics utils Eigen3::Eigen jsoncpp)
+ament_export_targets(rigid_body_dynamics HAS_LIBRARY_TARGET)
+
+install(
+  TARGETS rigid_body_dynamics
+  EXPORT rigid_body_dynamics
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include)
+
 ############################################################################
 
 if(BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# aaveq_dynamics
+# Aaveq Dynamics
 Collection of physics based functions, like computation of drag and rigid body dynamics. 

--- a/include/aaveq_dynamics/adynamics.hpp
+++ b/include/aaveq_dynamics/adynamics.hpp
@@ -1,0 +1,2 @@
+#include "aaveq_dynamics/utils.hpp"
+#include "aaveq_dynamics/rigid_body_dynamics.hpp"

--- a/include/aaveq_dynamics/rigid_body_dynamics.hpp
+++ b/include/aaveq_dynamics/rigid_body_dynamics.hpp
@@ -5,12 +5,11 @@
 
 namespace ADynamics
 {
-    struct PointMass
+    // Add .m() accesser to Eigen::Vector4d, equivalent to operator[](3)
+    class PointMass : public Eigen::Vector4d
     {
-        double m;
-        double x;
-        double y;
-        double z;
+    public:
+        double m() const { return (*this)[3]; }
     };
 
     Eigen::Matrix3d inertia_matrix(const std::vector<PointMass> &points);

--- a/include/aaveq_dynamics/rigid_body_dynamics.hpp
+++ b/include/aaveq_dynamics/rigid_body_dynamics.hpp
@@ -22,11 +22,14 @@ namespace ADynamics
 
     Eigen::Matrix<double, 6, 6> J_Theta(const Eigen::Vector<double, 6> &eta);
 
-    void rigid_body_dynamics(double timestep,
-                             const Eigen::Vector<double, 6> &tau,
-                             const Eigen::Matrix<double, 6, 6> &mass_matrix,
-                             const Eigen::Vector<double, 6> &state_body,
-                             const Eigen::Vector<double, 6> &state_earth);
+    typedef std::tuple<Eigen::Vector<double, 6>, Eigen::Vector<double, 6>, Eigen::Vector<double, 6>, Eigen::Vector<double, 6>> tubleStates;
+    tubleStates rigid_body_dynamics(double timestep,
+                                    const Eigen::Vector<double, 6> &tau,
+                                    const Eigen::Vector<double, 6> &state_body,
+                                    const Eigen::Vector<double, 6> &state_earth,
+                                    const double &mass,
+                                    const Eigen::Matrix3d &inertia_matrix,
+                                    const Eigen::Matrix<double, 6, 6> &mass_matrix);
 
 } // namespace ADynamics
 

--- a/include/aaveq_dynamics/rigid_body_dynamics.hpp
+++ b/include/aaveq_dynamics/rigid_body_dynamics.hpp
@@ -1,0 +1,34 @@
+#ifndef RIGID_BODY_DYNAMICS_H_
+#define RIGID_BODY_DYNAMICS_H_
+
+#include <Eigen/Dense>
+
+namespace ADynamics
+{
+    struct PointMass
+    {
+        double m;
+        double x;
+        double y;
+        double z;
+    };
+
+    Eigen::Matrix3d inertia_matrix(const std::vector<PointMass> &points);
+
+    Eigen::Matrix<double, 6, 6> mass_matrix(const double &mass, const Eigen::Matrix3d &inertia_matrix);
+
+    Eigen::Matrix<double, 6, 6> coriolis_matrix(const double &mass, const Eigen::Matrix3d &inertia_matrix, const Eigen::Vector<double, 6> &nu);
+
+    Eigen::Matrix3d transformation_matrix(const Eigen::Vector3d &attitude);
+
+    Eigen::Matrix<double, 6, 6> J_Theta(const Eigen::Vector<double, 6> &eta);
+
+    void rigid_body_dynamics(double timestep,
+                             const Eigen::Vector<double, 6> &tau,
+                             const Eigen::Matrix<double, 6, 6> &mass_matrix,
+                             const Eigen::Vector<double, 6> &state_body,
+                             const Eigen::Vector<double, 6> &state_earth);
+
+} // namespace ADynamics
+
+#endif // RIGID_BODY_DYNAMICS_H_

--- a/include/aaveq_dynamics/utils.hpp
+++ b/include/aaveq_dynamics/utils.hpp
@@ -1,0 +1,17 @@
+#ifndef UTILS_H_
+#define UTILS_H_
+
+#include <Eigen/Dense>
+
+namespace ADynamics
+{
+
+    Eigen::Matrix3d skew_symmetric_matrix(const Eigen::Vector3d &v);
+
+    Eigen::Matrix<double, 6, 6> matrix_inverse(const Eigen::Matrix<double, 6, 6> &matrix);
+
+    Eigen::Matrix3d rotation_matrix_eb(const Eigen::Vector3d &attitude);
+
+} // namespace ADynamics
+
+#endif // UTILS_H_

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>aaveq_dynamics</name>
+  <version>0.0.0</version>
+  <description>Collection of physics based functions, like computation of drag and rigid body dynamics.</description>
+  <maintainer email="nicoline@finman.dk">Nicoline L. Thomsen</maintainer>
+  <license>TODO: license</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <exec_depend>eigen</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/rigid_body_dynamics.cpp
+++ b/src/rigid_body_dynamics.cpp
@@ -56,21 +56,17 @@ namespace ADynamics
         return J_Theta;
     }
 
-    void rigid_body_dynamics(double timestep,
-                             const Eigen::Vector<double, 6> &tau,
-                             const Eigen::Vector<double, 6> &state_body,
-                             const Eigen::Vector<double, 6> &state_earth,
-                             const double &mass,
-                             const Eigen::Matrix3d &inertia_matrix,
-                             const Eigen::Matrix<double, 6, 6> &mass_matrix)
+    ADynamics::tubleStates rigid_body_dynamics(double timestep,
+                                               const Eigen::Vector<double, 6> &tau,
+                                               const Eigen::Vector<double, 6> &state_body,
+                                               const Eigen::Vector<double, 6> &state_earth,
+                                               const double &mass,
+                                               const Eigen::Matrix3d &inertia_matrix,
+                                               const Eigen::Matrix<double, 6, 6> &mass_matrix)
 
     {
         Eigen::Vector<double, 6> nu = state_body;
         Eigen::Vector<double, 6> eta = state_earth;
-
-        // Check time
-        if (timestep < 0.0)
-            return;
 
         // Rigid body dynamics
         Eigen::Vector<double, 6> nu_dot = matrix_inverse(mass_matrix) * tau - matrix_inverse(mass_matrix) * coriolis_matrix(mass, inertia_matrix, nu) * nu;
@@ -78,11 +74,11 @@ namespace ADynamics
         nu += nu_dot;
 
         // Body-fixed frame to earth-fixed frame
-        Eigen::Vector<double, 6> etadot = J_Theta(eta) * nu;
-        etadot *= timestep;
-        eta += etadot;
+        Eigen::Vector<double, 6> eta_dot = J_Theta(eta) * nu;
+        eta_dot *= timestep;
+        eta += eta_dot;
 
-        // TODO: return nu and eta
+        return std::make_tuple(nu, nu_dot, eta, eta_dot);
     }
 
 } // namespace ADynamics

--- a/src/rigid_body_dynamics.cpp
+++ b/src/rigid_body_dynamics.cpp
@@ -1,4 +1,5 @@
 #include "aaveq_dynamics/utils.hpp"
+
 #include "aaveq_dynamics/rigid_body_dynamics.hpp"
 
 namespace ADynamics

--- a/src/rigid_body_dynamics.cpp
+++ b/src/rigid_body_dynamics.cpp
@@ -1,0 +1,88 @@
+#include "aaveq_dynamics/utils.hpp"
+#include "aaveq_dynamics/rigid_body_dynamics.hpp"
+
+namespace ADynamics
+{
+
+    Eigen::Matrix3d inertia_matrix(const std::vector<PointMass> &points)
+    {
+        auto inertia = [](double x, double y, double z) -> Eigen::Matrix3d
+        {
+            return Eigen::Matrix3d{{std::pow(y, 2) + std::pow(z, 2), -x * y, -x * z},
+                                   {-x * y, std::pow(x, 2) + std::pow(z, 2), -y * z},
+                                   {-x * z, -y * z, std::pow(x, 2) + std::pow(y, 2)}};
+        };
+
+        Eigen::Matrix3d I;
+        for (auto p : points)
+            I += p.m * inertia(p.x, p.y, p.z);
+
+        return I;
+    }
+
+    Eigen::Matrix<double, 6, 6> mass_matrix(const double &mass, const Eigen::Matrix3d &inertia_matrix)
+    {
+        Eigen::Matrix<double, 6, 6> mass_matrix;
+        mass_matrix << mass * Eigen::Matrix3d::Identity(), Eigen::Matrix3d::Zero(), Eigen::Matrix3d::Zero(), inertia_matrix;
+
+        return mass_matrix;
+    }
+
+    Eigen::Matrix<double, 6, 6> coriolis_matrix(const double &mass, const Eigen::Matrix3d &inertia_matrix, const Eigen::Vector<double, 6> &nu)
+    {
+        Eigen::Vector<double, 3> omega = nu.tail(3); // Get last 3 elements
+        Eigen::Matrix<double, 6, 6> coriolis_matrix;
+        coriolis_matrix << mass * skew_symmetric_matrix(omega), Eigen::Matrix3d::Zero(), Eigen::Matrix3d::Zero(), -skew_symmetric_matrix(inertia_matrix * omega);
+
+        return coriolis_matrix;
+    }
+
+    Eigen::Matrix3d transformation_matrix(const Eigen::Vector3d &attitude)
+    {
+        double phi = attitude.x();
+        double theta = attitude.y();
+
+        return Eigen::Matrix3d{{1, sin(phi) * (sin(theta) / cos(theta)), cos(phi) * (sin(theta) / cos(theta))},
+                               {0, cos(phi), -sin(phi)},
+                               {0, sin(phi) / cos(theta), cos(phi) / cos(theta)}};
+    }
+
+    Eigen::Matrix<double, 6, 6> J_Theta(const Eigen::Vector<double, 6> &eta)
+    {
+        Eigen::Vector<double, 3> Omega = eta.tail(3); // Get last 3 elements
+        Eigen::Matrix<double, 6, 6> J_Theta;
+        J_Theta << rotation_matrix_eb(Omega), Eigen::Matrix3d::Zero(), Eigen::Matrix3d::Zero(), transformation_matrix(Omega);
+
+        return J_Theta;
+    }
+
+    void rigid_body_dynamics(double timestep,
+                             const Eigen::Vector<double, 6> &tau,
+                             const Eigen::Vector<double, 6> &state_body,
+                             const Eigen::Vector<double, 6> &state_earth,
+                             const double &mass,
+                             const Eigen::Matrix3d &inertia_matrix,
+                             const Eigen::Matrix<double, 6, 6> &mass_matrix)
+
+    {
+        Eigen::Vector<double, 6> nu = state_body;
+        Eigen::Vector<double, 6> eta = state_earth;
+
+        // Check time
+        if (timestep < 0.0)
+            return;
+
+        // Rigid body dynamics
+        Eigen::Vector<double, 6> nu_dot = matrix_inverse(mass_matrix) * tau - matrix_inverse(mass_matrix) * coriolis_matrix(mass, inertia_matrix, nu) * nu;
+        nu_dot *= timestep;
+        nu += nu_dot;
+
+        // Body-fixed frame to earth-fixed frame
+        Eigen::Vector<double, 6> etadot = J_Theta(eta) * nu;
+        etadot *= timestep;
+        eta += etadot;
+
+        // TODO: return nu and eta
+    }
+
+} // namespace ADynamics

--- a/src/rigid_body_dynamics.cpp
+++ b/src/rigid_body_dynamics.cpp
@@ -15,7 +15,7 @@ namespace ADynamics
 
         Eigen::Matrix3d I;
         for (auto p : points)
-            I += p.m * inertia(p.x, p.y, p.z);
+            I += p.m() * inertia(p.x(), p.y(), p.z());
 
         return I;
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,34 @@
+#include "aaveq_dynamics/utils.hpp"
+
+namespace ADynamics
+{
+    Eigen::Matrix3d skew_symmetric_matrix(const Eigen::Vector3d &v)
+    {
+        return Eigen::Matrix3d{{0, -v.z(), v.y()}, {v.z(), 0, -v.x()}, {-v.y(), v.x(), 0}};
+    }
+
+    Eigen::Matrix<double, 6, 6> matrix_inverse(const Eigen::Matrix<double, 6, 6> &matrix)
+    {
+        const float epsilon = 1e-6f; // Small tolerance value
+
+        if (matrix.determinant() > epsilon)
+            return matrix.inverse();
+        else
+            return matrix.completeOrthogonalDecomposition().pseudoInverse();
+    }
+
+    Eigen::Matrix3d rotation_matrix_eb(const Eigen::Vector3d &attitude)
+    {
+        double phi = attitude.x();
+        double theta = attitude.y();
+        double psi = attitude.z();
+
+        // Rotation of earth-fixed (NED) frame with respect to body-fixed frame
+        Eigen::Matrix3d Rx{{1, 0, 0}, {0, cos(phi), -sin(phi)}, {0, sin(phi), cos(phi)}};
+        Eigen::Matrix3d Ry{{cos(theta), 0, sin(theta)}, {0, 1, 0}, {-sin(theta), 0, cos(theta)}};
+        Eigen::Matrix3d Rz{{cos(psi), -sin(psi), 0}, {sin(psi), cos(psi), 0}, {0, 0, 1}};
+
+        return Rz * Ry * Rx;
+    }
+
+} // namespace ADynamics


### PR DESCRIPTION
**WHY**

The functions that compute the dynamics in the [usv_sim_2d](https://github.com/Aaveq-Robotics/usv_sim_2d/tree/simple_rigid_body_dynamics) repository are not unique for this simulation and should be moved to its own package for general use in the future. 
It is also to avoid "[code smell](https://en.wikipedia.org/wiki/Code_smell)", mainly the violation of the [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle).

**WHAT**

- Imported functions from [usv_sim_2d (simple_rigid_body_dynamics branch)](https://github.com/Aaveq-Robotics/usv_sim_2d/tree/simple_rigid_body_dynamics)
- [Changed PoitMass struct to be class that inherits from Eigen::Vector4d](https://github.com/Aaveq-Robotics/aaveq_dynamics/commit/69ab9d29ef2f011cdcdf6100ad9ec30427b29808)
- [Added header file that includes everything in library](https://github.com/Aaveq-Robotics/aaveq_dynamics/commit/fb5bafc7e9e54082e7745abe5680f20e7eeb9de3)

**RELATED**

